### PR TITLE
🐛fix: &amp; 이스케이핑 처리로 문자 메시지 잘 출력

### DIFF
--- a/src/main/java/site/what2eat/meal/global/jsoup/MealPlanParser.java
+++ b/src/main/java/site/what2eat/meal/global/jsoup/MealPlanParser.java
@@ -54,8 +54,10 @@ public class MealPlanParser {
     }
 
     private List<String> getMealPlanList(Element mealPlan) {
+        log.info("getMealPlanList: {}", mealPlan);
+        log.info("getMealPlanList: {}", mealPlan.text());
         // 파싱한 식단표에서 <br>을 기준으로 배열 생성
-        return Arrays.stream(mealPlan.html().split("<br>"))
+        return Arrays.stream(mealPlan.text().split(" "))
                 // 배열의 각각의 요소가 만약에 괄호로 감싸져 있다면 제거
                 .map(menu -> menu.replaceAll(("\\(.*?\\)"), "").trim())
                 // 괄호로 감싸져 있던 문자열들이 ""이 되었으므로 비어있는 ""들을 제거


### PR DESCRIPTION
 **이제 "크로와상&amp;누텔라&amp;쨈" 이렇게 안나옴!**
```(json)
"result": {
    "day": "금",
    "date": "2025-09-19",
    "breakfast": [
      "크로와상&amp;누텔라&amp;쨈",
      "달걀파이",
      "샤인머스캣",
      "시리얼",
      "우유"
    ],
    "lunch": [
      "찰밥",
      "엄나무닭곰탕",
      "갈치조림",
      "허니자몽",
      "애호박나물",
      "석박지"
    ],
    "dinner": [
      "김밥볶음밥",
      "물만둣국",
      "로제떡볶이",
      "쿨피스",
      "파래김",
      "오이김치"
    ]
  }
```