### PR TITLE
🐛fix: 괄호 사이에 띄어쓰기가 있을 때, 파싱이 잘 되지 않던 오류 수정

### DIFF
--- a/src/main/java/site/what2eat/meal/global/jsoup/MealPlanParser.java
+++ b/src/main/java/site/what2eat/meal/global/jsoup/MealPlanParser.java
@@ -54,12 +54,14 @@ public class MealPlanParser {
     }
 
     private List<String> getMealPlanList(Element mealPlan) {
-        log.info("getMealPlanList: {}", mealPlan);
-        log.info("getMealPlanList: {}", mealPlan.text());
+        log.info("getMealPlanListElement: {}", mealPlan);
+        log.info("getMealPlanListHtml: {}", mealPlan.html());
+        log.info("getMealPlanListText: {}", mealPlan.text());
         // 파싱한 식단표에서 <br>을 기준으로 배열 생성
-        return Arrays.stream(mealPlan.text().split(" "))
+        return Arrays.stream(mealPlan.html().split("<br>"))
                 // 배열의 각각의 요소가 만약에 괄호로 감싸져 있다면 제거
                 .map(menu -> menu.replaceAll(("\\(.*?\\)"), "").trim())
+                .map(menu -> menu.replaceAll("&amp;", "&").trim())
                 // 괄호로 감싸져 있던 문자열들이 ""이 되었으므로 비어있는 ""들을 제거
                 .filter(menu -> !menu.isEmpty())
                 // 리스트로 반환


### PR DESCRIPTION
getMealPlanListHtml: 
```
잡곡밥<br>
사골국&amp;송송대파<br>
(쇠고기_사골,잡뼈:국내산 한우)<br> (띄어쓰기가 있으면 split이 예상하는 대로 잘 안됐음)
(쇠고기_양지:호주산)<br>
오색모듬전<br>
꽈리고추멸치볶음<br>
얼갈이나물<br>
포기김치<br>
우유<br>
```